### PR TITLE
Adding Windows Packer Template

### DIFF
--- a/codecommit/ami-stuff/packer.json
+++ b/codecommit/ami-stuff/packer.json
@@ -2,7 +2,15 @@
   "builders": [{
     "type": "amazon-ebs",
     "region": "us-east-1",
-    "source_ami": "ami-72343365",
+    "source_ami_filter": {
+      "filters": {
+        "virtualization-type": "hvm",
+        "name": "*ubuntu-trusty-14.04-amd64-server*",
+        "root-device-type": "ebs"
+      },
+      "owners": ["099720109477"],
+      "most_recent": true
+    },
     "instance_type": "t2.micro",
     "ssh_username": "ubuntu",
     "ssh_pty" : true,

--- a/codecommit/ami-stuff/packerwindows.json
+++ b/codecommit/ami-stuff/packerwindows.json
@@ -1,0 +1,24 @@
+{
+  "builders": [{
+    "type": "amazon-ebs",
+    "communicator": "winrm",
+    "region": "us-east-1",
+    "source_ami_filter": {
+      "filters": {
+        "virtualization-type": "hvm",
+        "name": "Windows_Server-2012-R2_RTM-English-64Bit-Base*",
+        "root-device-type": "ebs"
+      },
+      "owners": ["801119661308"],
+      "most_recent": true
+    },
+    "instance_type": "t2.small",
+    "ami_name": "packer-ami-pipeline-demo-{{timestamp}}",
+    "winrm_username": "administrator",
+    "user_data_file":"ami-stuff/scripts/user-data.ps1"
+  }],
+  "provisioners": [{
+      "type": "powershell",
+      "scripts": [ "ami-stuff/scripts/provision.ps1" ]
+    }]
+}

--- a/codecommit/ami-stuff/scripts/provision.ps1
+++ b/codecommit/ami-stuff/scripts/provision.ps1
@@ -1,0 +1,5 @@
+tzutil /s "Central Standard Time"
+
+Install-WindowsFeature Web-Server
+Install-WindowsFeature Web-Mgmt-Tools
+Install-WindowsFeature Web-App-Dev -IncludeAllSubFeature

--- a/codecommit/ami-stuff/scripts/user-data.ps1
+++ b/codecommit/ami-stuff/scripts/user-data.ps1
@@ -1,0 +1,32 @@
+<powershell>
+write-output "Running User Data Script"
+write-host "(host) Running User Data Script"
+
+Set-ExecutionPolicy -ExecutionPolicy bypass -Force
+
+# RDP
+cmd.exe /c netsh advfirewall firewall add rule name="Open Port 3389" dir=in action=allow protocol=TCP localport=3389
+cmd.exe /c reg add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Terminal Server" /v fDenyTSConnections /t REG_DWORD /d 0 /f
+
+# WinRM
+write-output "Setting up WinRM"
+write-host "(host) setting up WinRM"
+
+cmd.exe /c winrm quickconfig -q
+cmd.exe /c winrm quickconfig '-transport:http'
+cmd.exe /c winrm set "winrm/config" '@{MaxTimeoutms="1800000"}'
+cmd.exe /c winrm set "winrm/config/winrs" '@{MaxMemoryPerShellMB="512"}'
+cmd.exe /c winrm set "winrm/config/service" '@{AllowUnencrypted="true"}'
+cmd.exe /c winrm set "winrm/config/client" '@{AllowUnencrypted="true"}'
+cmd.exe /c winrm set "winrm/config/service/auth" '@{Basic="true"}'
+cmd.exe /c winrm set "winrm/config/client/auth" '@{Basic="true"}'
+cmd.exe /c winrm set "winrm/config/service/auth" '@{CredSSP="true"}'
+cmd.exe /c winrm set "winrm/config/listener?Address=*+Transport=HTTP" '@{Port="5985"}'
+cmd.exe /c netsh advfirewall firewall set rule group="remote administration" new enable=yes
+cmd.exe /c netsh firewall add portopening TCP 5985 "Port 5985"
+cmd.exe /c net stop winrm
+cmd.exe /c sc config winrm start= auto
+cmd.exe /c net start winrm
+cmd.exe /c wmic useraccount where "name='codebuild'" set PasswordExpires=FALSE
+
+</powershell>

--- a/packer-ami-pipeline-roles.template
+++ b/packer-ami-pipeline-roles.template
@@ -1,11 +1,23 @@
 {
     "AWSTemplateFormatVersion": "2010-09-09",
     "Description": "AMI Builder Role Template",
+    "Parameters": {
+      "CodePipelineRoleName": {
+          "Description": "Name for the CodePipeline Role.",
+          "Type": "String",
+          "Default": "AWS-CodePipeline-Service"
+      },
+      "CodeBuildRoleName": {
+          "Description": "Name for the CodePipeline Role.",
+          "Type": "String",
+          "Default": "AWS-CodeBuild-Service"
+      }
+    },
     "Resources": {
       "CodePipelineRole": {
          "Type": "AWS::IAM::Role",
          "Properties": {
-           "RoleName": "AWS-CodePipeline-Service",
+           "RoleName":{ "Ref": "CodePipelineRoleName" },
            "AssumeRolePolicyDocument": {
            "Version" : "2012-10-17",
               "Statement": [ {
@@ -27,13 +39,13 @@
       "CodeBuildRole": {
          "Type": "AWS::IAM::Role",
          "Properties": {
-           "RoleName": "AWS-CodeBuild-Service",
+           "RoleName": { "Ref": "CodeBuildRoleName" },
            "AssumeRolePolicyDocument": {
              "Version" : "2012-10-17",
              "Statement": [ {
                 "Effect": "Allow",
                 "Principal": {
-                  "Service": "codebuild.amazonaws.com",
+                  "Service": "codebuild.amazonaws.com"
                 },
                 "Action": "sts:AssumeRole"
               } ]

--- a/packer-ami-pipeline.template
+++ b/packer-ami-pipeline.template
@@ -62,7 +62,7 @@
             "Type": "LINUX_CONTAINER"
           },
           "Source": {
-            "Type": "CODEPIPELINE",
+            "Type": "CODEPIPELINE"
           },
           "Artifacts": {
             "Type": "CODEPIPELINE"
@@ -131,11 +131,7 @@
                 }
               ]
             }
-          ],
-          "ArtifactStore": {
-            "Type": "S3",
-            "Location": { "Ref": "PipelineBucket" }
-          }
+          ]
         }
       }
     }


### PR DESCRIPTION
Changed the Linux builder to use source-ami-filter to grab latest AMI instead of us having to update it every so often for this blog post.

Added Windows packer file and a script to install IIS. This required turning on winrm using user-data script. Would need buildspec file to use the windows file instead of the linux one.
```
- ./packer build "ami-stuff/packerwindows.json"
```

Updated the CF Templates with some minor edits and some extra parameters to allow the changing of the Role Names.

